### PR TITLE
feat(Community): Display live repository stats on hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We are excited to welcome you to our community and look forward to building a be
 - **State Management**: [Zustand](https://zustand-demo.pmnd.rs/) - Small, fast state management
 - **Form Handling**: [React Hook Form](https://react-hook-form.com/) - Performant forms with validation
 - **Email Service**: [Nodemailer](https://nodemailer.com/) - Email sending functionality
+- **GitHub Integration**: Live repository stats via GitHub API with intelligent caching
 
 ## Getting Started
 
@@ -39,6 +40,27 @@ Before you begin, ensure you have the following installed:
 - **Node.js** (version 18.0 or higher)
 - **npm** (comes with Node.js)
 - **Git** for version control
+
+### Environment Variables
+
+Create a `.env.local` file in the root directory with the following variables:
+
+```bash
+# GitHub API Configuration (Optional - for higher rate limits)
+GITHUB_TOKEN=your_github_token_here
+GITHUB_REPO_OWNER=DarshanKrishna-DK
+GITHUB_REPO_NAME=KrowdKraft
+
+# Social Media URLs (Optional)
+NEXT_PUBLIC_TWITTER_URL=https://x.com/KrowdKraft_
+NEXT_PUBLIC_INSTAGRAM_URL=https://www.instagram.com/krowdkraft_/
+NEXT_PUBLIC_LINKEDIN_URL=https://www.linkedin.com/company/krowdkraft/
+
+# Email Configuration (Optional)
+GOOGLE_SHEETS_WEBHOOK_URL=your_google_sheets_webhook_url
+```
+
+**Note**: The GitHub stats feature will work without a token, but with rate limits. For production use, we recommend setting up a GitHub token.
 
 ### Installation
 

--- a/src/app/api/github-stats/route.ts
+++ b/src/app/api/github-stats/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface GitHubStats {
+  openIssues: number
+  mergedPRs: number
+  contributors: number
+  stars: number
+  forks: number
+  lastUpdated: string
+}
+
+// Cache for GitHub stats
+let statsCache: GitHubStats | null = null
+let cacheTimestamp: number = 0
+const CACHE_DURATION = 2 * 60 * 1000 // 2 minutes in milliseconds (reduced for fresher data)
+
+export async function GET(request: NextRequest) {
+  try {
+    const now = Date.now()
+    const url = new URL(request.url)
+    const forceRefresh = url.searchParams.get('refresh') === 'true'
+    
+    // Return cached data if it's still fresh and not forcing refresh
+    if (statsCache && (now - cacheTimestamp) < CACHE_DURATION && !forceRefresh) {
+      return NextResponse.json({
+        success: true,
+        data: statsCache,
+        cached: true
+      })
+    }
+
+    // GitHub API configuration
+    const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+    const REPO_OWNER = process.env.GITHUB_REPO_OWNER || 'DarshanKrishna-DK'
+    const REPO_NAME = process.env.GITHUB_REPO_NAME || 'KrowdKraft'
+    
+    if (!GITHUB_TOKEN) {
+      console.warn('GITHUB_TOKEN not found, using unauthenticated requests')
+    }
+
+    const headers: HeadersInit = {
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'KrowdKraft-Website'
+    }
+    
+    if (GITHUB_TOKEN) {
+      headers['Authorization'] = `token ${GITHUB_TOKEN}`
+    }
+
+    // Fetch repository data
+    const repoResponse = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`,
+      { headers }
+    )
+
+    if (!repoResponse.ok) {
+      throw new Error(`GitHub API error: ${repoResponse.status} ${repoResponse.statusText}`)
+    }
+
+    const repoData = await repoResponse.json()
+
+    // Fetch issues (open issues)
+    const issuesResponse = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues?state=open&per_page=100`,
+      { headers }
+    )
+
+    if (!issuesResponse.ok) {
+      throw new Error(`GitHub Issues API error: ${issuesResponse.status}`)
+    }
+
+    const issuesData = await issuesResponse.json()
+    const openIssues = issuesData.filter((issue: any) => !issue.pull_request).length
+
+    // Fetch pull requests (merged PRs)
+    const prsResponse = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=closed&per_page=100`,
+      { headers }
+    )
+
+    if (!prsResponse.ok) {
+      throw new Error(`GitHub PRs API error: ${prsResponse.status}`)
+    }
+
+    const prsData = await prsResponse.json()
+    const mergedPRs = prsData.filter((pr: any) => pr.merged_at).length
+
+    // Fetch contributors
+    const contributorsResponse = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contributors?per_page=100`,
+      { headers }
+    )
+
+    if (!contributorsResponse.ok) {
+      throw new Error(`GitHub Contributors API error: ${contributorsResponse.status}`)
+    }
+
+    const contributorsData = await contributorsResponse.json()
+    const contributors = contributorsData.length
+
+    // Prepare stats data
+    const stats: GitHubStats = {
+      openIssues,
+      mergedPRs,
+      contributors,
+      stars: repoData.stargazers_count,
+      forks: repoData.forks_count,
+      lastUpdated: new Date().toISOString()
+    }
+
+    // Update cache
+    statsCache = stats
+    cacheTimestamp = now
+
+    return NextResponse.json({
+      success: true,
+      data: stats,
+      cached: false
+    })
+
+  } catch (error) {
+    console.error('GitHub stats fetch error:', error)
+    
+    // Return cached data if available, even if stale
+    if (statsCache) {
+      return NextResponse.json({
+        success: true,
+        data: statsCache,
+        cached: true,
+        warning: 'Using cached data due to API error'
+      })
+    }
+
+    // Return fallback data if no cache available
+    return NextResponse.json({
+      success: false,
+      error: 'Failed to fetch GitHub stats',
+      fallback: {
+        openIssues: 0,
+        mergedPRs: 0,
+        contributors: 0,
+        stars: 0,
+        forks: 0,
+        lastUpdated: new Date().toISOString()
+      }
+    }, { status: 500 })
+  }
+}

--- a/src/components/sections/community/hero.tsx
+++ b/src/components/sections/community/hero.tsx
@@ -2,8 +2,17 @@
 
 import { motion } from "framer-motion"
 import { Button } from "@/components/ui/button"
-import { Users, PlusCircle, Instagram, Linkedin } from "lucide-react"
-import { useState } from "react"
+import { Users, PlusCircle, Instagram, Linkedin, Github, GitPullRequest, AlertCircle, Star } from "lucide-react"
+import { useState, useEffect } from "react"
+
+interface GitHubStats {
+  openIssues: number
+  mergedPRs: number
+  contributors: number
+  stars: number
+  forks: number
+  lastUpdated: string
+}
 
 // Custom X Logo Component
 const XIcon = ({ className }: { className?: string }) => (
@@ -65,6 +74,54 @@ const socialLinks = [
 ]
 
 export default function CommunityHero() {
+  const [githubStats, setGithubStats] = useState<GitHubStats | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchGitHubStats = async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+      
+      const response = await fetch('/api/github-stats')
+      const data = await response.json()
+      
+      if (data.success) {
+        setGithubStats(data.data)
+        console.log('GitHub stats updated:', data.cached ? 'from cache' : 'fresh data')
+      } else {
+        setError('Failed to fetch GitHub stats')
+        // Set fallback stats
+        setGithubStats({
+          openIssues: 0,
+          mergedPRs: 0,
+          contributors: 0,
+          stars: 0,
+          forks: 0,
+          lastUpdated: new Date().toISOString()
+        })
+      }
+    } catch (err) {
+      console.error('Error fetching GitHub stats:', err)
+      setError('Failed to fetch GitHub stats')
+      // Set fallback stats
+      setGithubStats({
+        openIssues: 0,
+        mergedPRs: 0,
+        contributors: 0,
+        stars: 0,
+        forks: 0,
+        lastUpdated: new Date().toISOString()
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchGitHubStats()
+  }, [])
+
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-b from-black to-gray-900 pt-20">
       {/* Enhanced Particle Background (reused from main hero) */}
@@ -198,28 +255,104 @@ export default function CommunityHero() {
              </motion.div>
            </motion.div>
 
-          {/* Stats */}
+          {/* GitHub Stats */}
           <motion.div 
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.6 }}
-            className="flex flex-wrap justify-center items-center gap-24 mb-20 max-w-2xl mx-auto"
+            className="flex flex-wrap justify-center items-center gap-8 md:gap-12 lg:gap-16 mb-20 max-w-4xl mx-auto"
           >
-            {[
-              { number: "900+", label: "Members" },
-              { number: "6", label: "Events" },
-            ].map((stat, index) => (
-              <motion.div 
-                key={stat.label}
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ duration: 0.5, delay: 0.8 + index * 0.1 }}
-                className="text-center"
-              >
-                <div className="text-2xl md:text-3xl font-bold neon-text">{stat.number}</div>
-                <div className="text-sm text-muted-foreground">{stat.label}</div>
-              </motion.div>
-            ))}
+            {githubStats ? (
+              [
+                { 
+                  number: githubStats.stars.toString(), 
+                  label: "Stars", 
+                  icon: Star,
+                  color: "text-yellow-400"
+                },
+                { 
+                  number: githubStats.mergedPRs.toString(), 
+                  label: "Merged PRs", 
+                  icon: GitPullRequest,
+                  color: "text-green-400"
+                },
+                { 
+                  number: githubStats.openIssues.toString(), 
+                  label: "Open Issues", 
+                  icon: AlertCircle,
+                  color: "text-orange-400"
+                },
+                { 
+                  number: githubStats.contributors.toString(), 
+                  label: "Contributors", 
+                  icon: Users,
+                  color: "text-blue-400"
+                },
+                { 
+                  number: githubStats.forks.toString(), 
+                  label: "Forks", 
+                  icon: Github,
+                  color: "text-purple-400"
+                }
+              ].map((stat, index) => {
+                const Icon = stat.icon
+                return (
+                  <motion.div 
+                    key={stat.label}
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ duration: 0.5, delay: 0.8 + index * 0.1 }}
+                    className="text-center group"
+                  >
+                    <div className="flex items-center justify-center mb-2">
+                      <Icon className={`w-5 h-5 mr-2 ${stat.color} group-hover:scale-110 transition-transform duration-200`} />
+                      <div className="text-2xl md:text-3xl font-bold neon-text">{stat.number}</div>
+                    </div>
+                    <div className="text-sm text-muted-foreground">{stat.label}</div>
+                  </motion.div>
+                )
+              })
+            ) : isLoading ? (
+              // Loading skeleton
+              Array.from({ length: 5 }, (_, index) => (
+                <motion.div 
+                  key={`loading-${index}`}
+                  initial={{ scale: 0, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 0.3 }}
+                  transition={{ duration: 0.5, delay: 0.8 + index * 0.1 }}
+                  className="text-center"
+                >
+                  <div className="w-16 h-8 bg-gray-600 rounded animate-pulse mb-2"></div>
+                  <div className="w-12 h-4 bg-gray-600 rounded animate-pulse"></div>
+                </motion.div>
+              ))
+            ) : (
+              // Fallback stats
+              [
+                { number: "0", label: "Stars", icon: Star },
+                { number: "0", label: "Merged PRs", icon: GitPullRequest },
+                { number: "0", label: "Open Issues", icon: AlertCircle },
+                { number: "0", label: "Contributors", icon: Users },
+                { number: "0", label: "Forks", icon: Github }
+              ].map((stat, index) => {
+                const Icon = stat.icon
+                return (
+                  <motion.div 
+                    key={stat.label}
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ duration: 0.5, delay: 0.8 + index * 0.1 }}
+                    className="text-center"
+                  >
+                    <div className="flex items-center justify-center mb-2">
+                      <Icon className="w-5 h-5 mr-2 text-gray-400" />
+                      <div className="text-2xl md:text-3xl font-bold neon-text">{stat.number}</div>
+                    </div>
+                    <div className="text-sm text-muted-foreground">{stat.label}</div>
+                  </motion.div>
+                )
+              })
+            )}
           </motion.div>
         </motion.div>
       </div>


### PR DESCRIPTION
- Add GitHub API integration to fetch live repository statistics
- Create /api/github-stats endpoint with intelligent caching (2min)
- Display stars, merged PRs, open issues, contributors, and forks
- Implement responsive design with color-coded icons and animations
- Add error handling with graceful fallbacks
- Update README with GitHub integration documentation
- Cache data to prevent GitHub API rate limiting
- Support both authenticated and unauthenticated requests

Resolves #20 