### PR TITLE
Update README workflow fix

### DIFF
--- a/.github/workflows/update-readme-stats.yml
+++ b/.github/workflows/update-readme-stats.yml
@@ -199,7 +199,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_TOKEN }}
           branch: chore/update-readme-stats
           base: main
           delete-branch: true


### PR DESCRIPTION
The auto-merge was being blocked by the rulesets enforced on main branch. Have use PAT to resolve the issue by raising PR from admin account instead of bot account.

