### PR TITLE
feat: update email routes and add email templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# Email Configuration
+# Email Configuration (used for notifications and confirmation emails)
 EMAIL_USER=
 EMAIL_PASS=
+# Optional: override default sender name (defaults to "KrowdKraft")
+# EMAIL_SENDER_NAME=KrowdKraft
+# Optional: add a BCC address for all outbound emails
+# EMAIL_BCC=
 
 # Google Sheets Integration
 GOOGLE_SHEETS_WEBHOOK_URL=

--- a/src/app/api/partner-request/route.ts
+++ b/src/app/api/partner-request/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
+import nodemailer from 'nodemailer'
+import { confirmationHtml, confirmationSubject } from '@/lib/email-templates'
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,13 +12,49 @@ export async function POST(request: NextRequest) {
     console.log('- GOOGLE_SHEETS_PARTNERSHIP_WEBHOOK_URL:', process.env.GOOGLE_SHEETS_PARTNERSHIP_WEBHOOK_URL ? 'SET' : 'NOT SET')
     console.log('- GOOGLE_SHEETS_WEBHOOK_URL:', process.env.GOOGLE_SHEETS_WEBHOOK_URL ? 'SET' : 'NOT SET')
 
-    const webhookUrl = process.env.GOOGLE_SHEETS_PARTNERSHIP_WEBHOOK_URL
+  const webhookUrl = process.env.GOOGLE_SHEETS_PARTNERSHIP_WEBHOOK_URL
+  const emailUser = process.env.EMAIL_USER || 'krowdkraft.official@gmail.com'
+  const emailPass = process.env.EMAIL_PASS
+  const emailSenderName = process.env.EMAIL_SENDER_NAME || 'KrowdKraft'
+  const emailBcc = process.env.EMAIL_BCC
 
     if (!webhookUrl) {
       console.log('GOOGLE_SHEETS_PARTNERSHIP_WEBHOOK_URL not configured, logging partnership request:', data)
-      return NextResponse.json({ 
-        success: true, 
-        message: 'Partnership request submitted successfully! (Google Sheets webhook not configured)' 
+      // Even if webhook isn't configured, still try to send confirmation email if SMTP is configured
+      if (emailPass && data?.email) {
+        try {
+          const transporter = nodemailer.createTransport({
+            host: 'smtp.gmail.com',
+            port: 587,
+            secure: false,
+            auth: { user: emailUser, pass: emailPass },
+            tls: { rejectUnauthorized: false },
+          })
+          await transporter.verify()
+          await transporter.sendMail({
+            from: `${emailSenderName} <${emailUser}>`,
+            to: data.email,
+            subject: confirmationSubject('partnership'),
+            html: confirmationHtml({
+              type: 'partnership',
+              name: data?.name || data?.organizationName,
+              details: [
+                { label: 'Organization', value: data?.organizationName },
+                { label: 'Mobile', value: data?.mobile },
+                { label: 'Email', value: data?.email },
+              ],
+            }),
+            replyTo: emailUser,
+            ...(emailBcc ? { bcc: emailBcc } : {}),
+          })
+          console.log('✅ Partnership confirmation email sent to user:', data.email)
+        } catch (e) {
+          console.warn('⚠️ Could not send partnership confirmation email:', e)
+        }
+      }
+      return NextResponse.json({
+        success: true,
+        message: 'Partnership request submitted successfully! (Google Sheets webhook not configured)'
       })
     }
 
@@ -51,9 +89,45 @@ export async function POST(request: NextRequest) {
       }
 
       console.log('Successfully added partnership request to Google Sheets:', responseText)
-      return NextResponse.json({ 
-        success: true, 
-        message: 'Partnership request submitted successfully!' 
+
+      // After successful webhook, attempt to send confirmation email to the user
+      try {
+        if (emailPass && data?.email) {
+          const transporter = nodemailer.createTransport({
+            host: 'smtp.gmail.com',
+            port: 587,
+            secure: false,
+            auth: { user: emailUser, pass: emailPass },
+            tls: { rejectUnauthorized: false },
+          })
+          await transporter.verify()
+          await transporter.sendMail({
+            from: `${emailSenderName} <${emailUser}>`,
+            to: data.email,
+            subject: confirmationSubject('partnership'),
+            html: confirmationHtml({
+              type: 'partnership',
+              name: data?.name || data?.organizationName,
+              details: [
+                { label: 'Organization', value: data?.organizationName },
+                { label: 'Mobile', value: data?.mobile },
+                { label: 'Email', value: data?.email },
+              ],
+            }),
+            replyTo: emailUser,
+            ...(emailBcc ? { bcc: emailBcc } : {}),
+          })
+          console.log('✅ Partnership confirmation email sent to user:', data.email)
+        } else {
+          console.log('ℹ️ Skipping partnership confirmation email: SMTP not configured or no user email')
+        }
+      } catch (emailErr) {
+        console.warn('⚠️ Failed to send partnership confirmation email:', emailErr)
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: 'Partnership request submitted successfully!'
       })
     } catch (webhookError) {
       console.error('Google Sheets webhook error:', webhookError)

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,0 +1,84 @@
+// Simple HTML email templates for user confirmations
+// Keep styles inline for better email client compatibility
+
+type SubmissionType = 'event-proposal' | 'quote-request' | 'partnership'
+
+function baseWrapper(content: string) {
+  return `
+  <div style="font-family: Arial, sans-serif; background-color: #f6f7fb; padding: 24px;">
+    <div style="max-width: 640px; margin: 0 auto; background: #ffffff; border-radius: 12px; box-shadow: 0 2px 10px rgba(0,0,0,0.06); overflow: hidden;">
+      <div style="background: linear-gradient(90deg, #8b5cf6, #6d28d9); height: 6px;"></div>
+      <div style="padding: 28px;">
+        ${content}
+      </div>
+      <div style="padding: 16px 28px; color: #6b7280; font-size: 12px; border-top: 1px solid #f1f5f9;">
+        © ${new Date().getFullYear()} KrowdKraft — This is an automated message, please reply if you have any questions.
+      </div>
+    </div>
+  </div>
+  `
+}
+
+export function confirmationSubject(type: SubmissionType) {
+  switch (type) {
+    case 'event-proposal':
+      return 'Thanks for your event proposal — KrowdKraft'
+    case 'quote-request':
+      return 'Thanks for your request — KrowdKraft'
+    case 'partnership':
+      return 'Thanks for your partnership request — KrowdKraft'
+    default:
+      return 'Thanks for reaching out — KrowdKraft'
+  }
+}
+
+export function confirmationHtml(options: {
+  type: SubmissionType
+  name?: string
+  details?: Array<{ label: string; value?: string }>
+}) {
+  const { type, name, details = [] } = options
+
+  const title =
+    type === 'event-proposal'
+      ? 'Event proposal received'
+      : type === 'partnership'
+      ? 'Partnership request received'
+      : 'Request received'
+
+  const intro = `Hi${name ? ` ${escapeHtml(name)}` : ''},`;
+
+  const detailRows = details
+    .filter((d) => d.value && String(d.value).trim().length > 0)
+    .slice(0, 8) // keep it short
+    .map(
+      (d) => `
+        <tr>
+          <td style="padding: 6px 0; color: #6b7280;">${escapeHtml(d.label)}:</td>
+          <td style="padding: 6px 0; color: #111827; font-weight: 600;">${escapeHtml(String(d.value))}</td>
+        </tr>
+      `
+    )
+    .join('')
+
+  const body = `
+    <h2 style="margin: 0 0 12px; color: #111827;">${title}</h2>
+    <p style="margin: 0 0 12px; color: #374151;">${intro}</p>
+    <p style="margin: 0 0 16px; color: #374151;">Thanks for your submission. Our team will review the details and get back to you shortly.</p>
+    ${detailRows
+      ? `<table style="width: 100%; margin: 12px 0 16px; border-collapse: collapse;">${detailRows}</table>`
+      : ''}
+    <p style="margin: 16px 0 0; color: #6b7280; font-size: 13px;">If any of the above details need correction, just reply to this email with the updates.</p>
+  `
+
+  return baseWrapper(body)
+}
+
+function escapeHtml(input: string) {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}


### PR DESCRIPTION
## Description
Added a reusable email template utility and updated the `partner-request` and `send-email` API routes to use it.  
This improves maintainability and ensures consistent email formatting across the application.

## Type of Change
- New feature (non-breaking change)

## How Has This Been Tested?
- Verified locally by sending test email requests.
- Confirmed proper rendering of HTML templates in received emails.
- Checked successful API responses and error handling.

## Screenshots (if applicable)
N/A

## Checklist
- Code follows the project’s style and linting guidelines: **Yes**
- Lint and build pass locally: **Yes**
- Relevant tests pass: **Yes**
- All new code is type-safe and documented: **Yes**

## Summary of Changes
- Created `email-templates.ts` for clean, reusable confirmation email HTML.
- Updated `src/app/api/send-email/route.ts` to send confirmation emails after form submission.
- Updated `src/app/api/partner-request/route.ts` to send confirmation emails after partnership requests.
- Enhanced `.env.example` with mail sender and BCC options.
- Ensured all new code is type-safe, linted, and covered by existing test routines.

## Additional Notes
This PR enhances the email infrastructure for future features and improves developer experience by centralizing email template logic.
